### PR TITLE
[APP-1593] Add locked variant for quota bar

### DIFF
--- a/modules/settings/assets/js/components/quota-bar/data.js
+++ b/modules/settings/assets/js/components/quota-bar/data.js
@@ -21,5 +21,9 @@ export const QuotaBarData = {
 			'This is how many AI credits you’ve used to resolve issues or to generate content. Upgrade if you’re nearing your plan limit to keep full functionality.',
 			'pojo-accessibility',
 		),
+		lockedDescription: __(
+			'Upgrade your plan to unlock AI credits for generating alt‑text, one‑click accessibility fixes, and more.',
+			'pojo-accessibility',
+		),
 	},
 };

--- a/modules/settings/assets/js/components/quota-bar/index.js
+++ b/modules/settings/assets/js/components/quota-bar/index.js
@@ -40,11 +40,7 @@ const QuotaBar = ({ type, quotaData }) => {
 						placement="right"
 						PopperProps={{ sx: { width: '300px' }, disablePortal: true }}
 						content={
-							<Typography
-								color={!isLocked ? 'text.secondary' : 'text.disabled'}
-								variant="body2"
-								padding={2}
-							>
+							<Typography color="text.secondary" variant="body2" padding={2}>
 								{!isLocked
 									? QuotaBarData[type]?.infotipDescription
 									: QuotaBarData[type]?.lockedDescription}

--- a/modules/settings/assets/js/components/quota-bar/index.js
+++ b/modules/settings/assets/js/components/quota-bar/index.js
@@ -8,7 +8,10 @@ import { QuotaBarData } from '@ea11y/components/quota-bar/data';
 import { formatPlanValue } from '../../utils/index';
 
 const QuotaBar = ({ type, quotaData }) => {
-	const planUsage = Math.round((quotaData?.used / quotaData?.allowed) * 100);
+	const planUsage =
+		quotaData?.allowed === 0
+			? 0
+			: Math.round((quotaData?.used / quotaData?.allowed) * 100);
 	const isLocked = quotaData?.allowed === 0;
 
 	/**

--- a/modules/settings/assets/js/components/quota-bar/index.js
+++ b/modules/settings/assets/js/components/quota-bar/index.js
@@ -1,4 +1,4 @@
-import { InfoCircleIcon } from '@elementor/icons';
+import { InfoCircleIcon, LockFilledIcon } from '@elementor/icons';
 import { styled } from '@elementor/ui';
 import Box from '@elementor/ui/Box';
 import Infotip from '@elementor/ui/Infotip';
@@ -9,6 +9,7 @@ import { formatPlanValue } from '../../utils/index';
 
 const QuotaBar = ({ type, quotaData }) => {
 	const planUsage = Math.round((quotaData?.used / quotaData?.allowed) * 100);
+	const isLocked = quotaData?.allowed === 0;
 
 	/**
 	 * Get the color for the progress bar based on the usage.
@@ -29,7 +30,7 @@ const QuotaBar = ({ type, quotaData }) => {
 			<Box display="flex" justifyContent="space-between">
 				<Typography
 					variant="body2"
-					color="text.secondary"
+					color={!isLocked ? 'text.secondary' : 'text.disabled'}
 					display="flex"
 					alignItems="center"
 					sx={{ fontSize: '12px' }}
@@ -39,35 +40,47 @@ const QuotaBar = ({ type, quotaData }) => {
 						placement="right"
 						PopperProps={{ sx: { width: '300px' }, disablePortal: true }}
 						content={
-							<Typography color="text.secondary" variant="body2" padding={2}>
-								{QuotaBarData[type]?.infotipDescription}
+							<Typography
+								color={!isLocked ? 'text.secondary' : 'text.disabled'}
+								variant="body2"
+								padding={2}
+							>
+								{!isLocked
+									? QuotaBarData[type]?.infotipDescription
+									: QuotaBarData[type]?.lockedDescription}
 							</Typography>
 						}
 					>
-						<InfoCircleIcon
-							sx={{
-								fontSize: 'medium',
-							}}
-						/>
+						{!isLocked ? (
+							<InfoCircleIcon
+								sx={{
+									fontSize: 'medium',
+								}}
+							/>
+						) : (
+							<LockFilledIcon
+								sx={{ fontSize: 'medium', color: 'text.primary', opacity: 0.5 }}
+							/>
+						)}
 					</Infotip>
 				</Typography>
-				{quotaData?.allowed && (
-					<Box display="flex" flexDirection="row" gap={0.5} alignItems="center">
-						<Typography
-							variant="body2"
-							color="text.primary"
-							sx={{ fontSize: '12px' }}
-						>
-							{formatPlanValue(quotaData?.used)}/
-							{formatPlanValue(quotaData?.allowed)}
-						</Typography>
-					</Box>
-				)}
+				<Box display="flex" flexDirection="row" gap={0.5} alignItems="center">
+					<Typography
+						variant="body2"
+						color={!isLocked ? 'text.primary' : 'text.disabled'}
+						sx={{ fontSize: '12px' }}
+					>
+						{!isLocked
+							? `${formatPlanValue(quotaData?.used)} / ${formatPlanValue(quotaData?.allowed)}`
+							: '0/0'}
+					</Typography>
+				</Box>
 			</Box>
 			<LinearProgress
 				sx={{
 					'& .MuiLinearProgress-bar': {
 						animation: 'none',
+						backgroundColor: isLocked && 'text.disabled',
 					},
 					animation: 'none',
 				}}

--- a/modules/settings/assets/js/pages/icon-settings.js
+++ b/modules/settings/assets/js/pages/icon-settings.js
@@ -1,10 +1,8 @@
+import Typography from '@elementor/ui/Typography';
+import { styled } from '@elementor/ui/styles';
 import { BottomBar } from '@ea11y/components';
 import { IconDesignSettings, PositionSettings } from '@ea11y/layouts';
-import {
-	StyledBox,
-	StyledTitle,
-	StyledWideBox,
-} from '@ea11y/pages/pages.styles';
+import { StyledBox, StyledWideBox } from '@ea11y/pages/pages.styles';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -33,3 +31,14 @@ const IconSettings = () => {
 };
 
 export default IconSettings;
+
+const StyledTitle = styled(Typography)`
+	max-width: 1200px;
+	// Spacing
+	margin-bottom: 16px;
+	margin-right: auto;
+	margin-left: auto;
+	// Typography
+	font-weight: 400;
+	letter-spacing: 0.25px;
+`;

--- a/modules/settings/assets/js/pages/menu.js
+++ b/modules/settings/assets/js/pages/menu.js
@@ -1,13 +1,10 @@
 import Box from '@elementor/ui/Box';
+import Typography from '@elementor/ui/Typography';
 import { styled } from '@elementor/ui/styles';
 import { BottomBar } from '@ea11y/components';
 import SkipToContentSettings from '@ea11y/components/skip-to-content-settings';
 import { MenuSettings, WidgetPreview } from '@ea11y/layouts';
-import {
-	StyledBox,
-	StyledTitle,
-	StyledWideBox,
-} from '@ea11y/pages/pages.styles';
+import { StyledBox, StyledWideBox } from '@ea11y/pages/pages.styles';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -22,11 +19,7 @@ const Menu = () => {
 	return (
 		<StyledBox>
 			<StyledWideBox>
-				<StyledTitle
-					variant="h4"
-					color="text.primary"
-					sx={{ width: '50%', marginLeft: 'auto', marginRight: 'auto' }}
-				>
+				<StyledTitle variant="h4" color="text.primary">
 					{__('Capabilities', 'pojo-accessibility')}
 				</StyledTitle>
 
@@ -48,11 +41,16 @@ const StyledSettingsWrapper = styled(Box)`
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	gap: ${({ theme }) => theme.spacing(4)};
-	width: 50%;
+	max-width: 1200px;
 	margin-left: auto;
 	margin-right: auto;
+`;
 
-	${({ theme }) => theme.breakpoints.down('xl')} {
-		width: 100%;
-	}
+const StyledTitle = styled(Typography)`
+	font-weight: 400;
+	letter-spacing: 0.25px;
+	margin-bottom: 16px;
+	max-width: 1200px;
+	margin-right: auto;
+	margin-left: auto;
 `;


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Enhance QuotaBar component to display a locked state for AI credits with appropriate UI indicators when allowed quota is zero.

Main changes:
- Added lockedDescription text for AI credits in QuotaBarData component
- Implemented isLocked state logic when quotaData.allowed equals zero
- Modified UI elements to show lock icon and disabled styling for locked quota bars
- Refactored StyledTitle component to maintain consistent styling across pages

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
