### PR TITLE
Fix: Update the results table data [APP-1693]

### DIFF
--- a/modules/scanner/rest/scanner-results.php
+++ b/modules/scanner/rest/scanner-results.php
@@ -43,9 +43,6 @@ class Scanner_Results extends Route_Base {
 			$pages_scanned = Page_Entry::get_pages();
 
 			foreach ( $pages_scanned as $page ) {
-				$total_violations = 0;
-				$total_resolved = 0;
-
 				$scans = Scan_Entry::get_scans( $page->url );
 				$page_remediation_count = Remediation_Entry::get_page_remediations( $page->url, true );
 
@@ -66,11 +63,6 @@ class Scanner_Results extends Route_Base {
 					continue;
 				}
 
-				foreach ( $recent_scans as $recent_scan ) {
-					$total_violations += $recent_scan['issues_total'];
-					$total_resolved += $recent_scan['issues_fixed'];
-				}
-
 				$output[] = [
 					'id' => $page->id,
 					'page_title' => $page->title ? $page->title : ( 'home' === $page->object_type ?
@@ -80,8 +72,8 @@ class Scanner_Results extends Route_Base {
 					'scans' => $scans,
 					'last_scan' => $scans[0]['date'] ?: $page->created_at,
 					'remediation_count' => isset( $page_remediation_count[0] ) ? $page_remediation_count[0]->total : 0,
-					'issues_total' => $total_violations,
-					'issues_fixed' => $total_resolved,
+					'issues_total' => $scans[0]['issues_total'],
+					'issues_fixed' => $scans[0]['issues_fixed'],
 				];
 			}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Optimizes the Scanner_Results REST endpoint by using only the most recent scan data instead of aggregating all recent scans.

Main changes:
- Removed code that calculated total violations and resolutions across multiple scans
- Modified issues_total and issues_fixed to only use data from most recent scan
- Removed redundant variables total_violations and total_resolved that accumulated historical scan data

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
