### PR TITLE
Tweak: Remove block scripts from front end

### DIFF
--- a/classes/utils/assets.php
+++ b/classes/utils/assets.php
@@ -104,10 +104,9 @@ class Assets {
 	 * @param string $handle
 	 * @param bool $with_css
 	 */
-	public static function enqueue_app_assets( string $handle = '', bool $with_css = true ) : void {
+	public static function enqueue_app_assets( string $handle = '', bool $with_css = true, array $dependencies = [] ) : void {
 		$dir = \EA11Y_ASSETS_PATH . 'build/';
 		$url = \EA11Y_ASSETS_URL . 'build/';
-
 		$script_asset_path = $dir . $handle . '.asset.php';
 		if ( ! file_exists( $script_asset_path ) ) {
 			throw new \Error(
@@ -120,7 +119,7 @@ class Assets {
 		wp_enqueue_script(
 			$handle,
 			$url . $handle . '.js',
-			array_merge( $script_asset['dependencies'], [ 'wp-util', 'wp-block-editor', 'wp-components' ] ),
+			array_merge( $script_asset['dependencies'], $dependencies ),
 			$script_asset['version'],
 			true,
 		);

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -94,7 +94,7 @@ class Module extends Module_Base {
 			EA11Y_VERSION
 		);
 
-		Utils\Assets::enqueue_app_assets( 'admin' );
+		Utils\Assets::enqueue_app_assets( 'admin', true, [ 'wp-util', 'wp-block-editor', 'wp-components' ] );
 
 		wp_localize_script(
 			'admin',

--- a/modules/widget/components/gutenberg-link.php
+++ b/modules/widget/components/gutenberg-link.php
@@ -14,7 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Gutenberg_Link {
 
 	public function enqueue_custom_link_block_assets() {
-		Assets::enqueue_app_assets( 'gutenberg-custom-link', false );
+		register_block_type( 'ally/custom-link', [] );
+		if ( is_admin() ) {
+			Assets::enqueue_app_assets( 'gutenberg-custom-link', false );
+		}
 	}
 
 	public function enqueue_custom_link_block_frontend( $block_content ) {

--- a/modules/widget/module.php
+++ b/modules/widget/module.php
@@ -219,7 +219,7 @@ class Module extends Module_Base {
 		?>
 			<script>
 				const registerAllyAction = () => {
-					if ( ! window?.elementorAppConfig?.hasPro ) {
+					if ( ! window?.elementorAppConfig?.hasPro || ! window?.elementorFrontend?.utils?.urlActions ) {
 						return;
 					}
 


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Refactor front-end script loading to optimize performance by removing unnecessary block editor dependencies from non-admin contexts.
Main changes:
- Added optional dependencies parameter to enqueue_app_assets method for more flexible script loading
- Modified gutenberg-custom-link to only load in admin contexts and properly register the block
- Added safety check for elementorFrontend.utils.urlActions existence in dynamic tag handler

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
