### PR TITLE
[APP-1766] Remove visit quota indications

### DIFF
--- a/modules/settings/assets/js/app.js
+++ b/modules/settings/assets/js/app.js
@@ -15,7 +15,7 @@ import {
 	useSavedSettings,
 	useSettings,
 } from '@ea11y/hooks';
-import { QuotaNotices, Sidebar, TopBar } from '@ea11y/layouts';
+import { Sidebar, TopBar } from '@ea11y/layouts';
 import { mixpanelEvents, mixpanelService } from '@ea11y-apps/global/services';
 import { useEffect } from '@wordpress/element';
 import { usePluginSettingsContext } from './contexts/plugin-settings';
@@ -59,7 +59,6 @@ const App = () => {
 					<Sidebar />
 
 					<StyledContainer>
-						<QuotaNotices />
 						<PageContent
 							// Looks the best if we have both checks
 							isLoading={!hasFinishedResolution || loading}

--- a/modules/settings/assets/js/components/quota-bar/quota-bar-group.js
+++ b/modules/settings/assets/js/components/quota-bar/quota-bar-group.js
@@ -48,7 +48,6 @@ const QuotaBarGroup = ({ collapsible = true, popup = false }) => {
 
 	const QuotaBars = () => (
 		<StyledCardContentInner>
-			<QuotaBarComponent type="visits" quotaData={planData?.visits} />
 			<QuotaBarComponent type="scanner" quotaData={planData?.scannedPages} />
 			<QuotaBarComponent type="ai" quotaData={planData?.aiCredits} />
 		</StyledCardContentInner>

--- a/modules/settings/assets/js/components/quota-bar/quota-indicator.js
+++ b/modules/settings/assets/js/components/quota-bar/quota-indicator.js
@@ -9,27 +9,24 @@ import { __ } from '@wordpress/i18n';
 const QuotaIndicator = () => {
 	const { planData, openSidebar } = useSettings();
 
-	if (!planData?.scannedPages || !planData?.visits || !planData?.aiCredits) {
+	if (!planData?.scannedPages || !planData?.aiCredits) {
 		return null; // Return null if data is not available
 	}
 
-	const { scannedPages, visits, aiCredits } = planData;
+	const { scannedPages, aiCredits } = planData;
 
 	// calculate usage data of each quota
 	const scannedPagesUsage = Math.round(
 		(scannedPages.used / scannedPages.allowed) * 100,
 	);
-	const visitsUsage = Math.round((visits.used / visits.allowed) * 100);
 	const aiCreditsUsage = Math.round((aiCredits.used / aiCredits.allowed) * 100);
 
 	// check if any of the quota is 100% used
-	const isQuotaExceeded =
-		scannedPagesUsage >= 100 || visitsUsage >= 100 || aiCreditsUsage >= 100;
+	const isQuotaExceeded = scannedPagesUsage >= 100 || aiCreditsUsage >= 100;
 
 	// check if any of the quota is 80% but not 100% used
 	const isQuotaWarning =
 		(scannedPagesUsage >= 80 && scannedPagesUsage < 100) ||
-		(visitsUsage >= 80 && visitsUsage < 100) ||
 		(aiCreditsUsage >= 80 && aiCreditsUsage < 100);
 
 	if (isQuotaExceeded) {

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -539,6 +539,7 @@ class Module extends Module_Base {
 		add_action( 'on_connect_' . Config::APP_PREFIX . '_connected', [ $this, 'on_connect' ] );
 		add_action( 'current_screen', [ $this, 'check_plan_data' ] );
 		// Register notices
-		//add_action( 'ea11y_register_notices', [ $this, 'register_notices' ] );
+		// Removed visits quota
+		// add_action( 'ea11y_register_notices', [ $this, 'register_notices' ] );
 	}
 }

--- a/modules/settings/module.php
+++ b/modules/settings/module.php
@@ -539,6 +539,6 @@ class Module extends Module_Base {
 		add_action( 'on_connect_' . Config::APP_PREFIX . '_connected', [ $this, 'on_connect' ] );
 		add_action( 'current_screen', [ $this, 'check_plan_data' ] );
 		// Register notices
-		add_action( 'ea11y_register_notices', [ $this, 'register_notices' ] );
+		//add_action( 'ea11y_register_notices', [ $this, 'register_notices' ] );
 	}
 }

--- a/modules/settings/notices/quota-100.php
+++ b/modules/settings/notices/quota-100.php
@@ -30,6 +30,10 @@ class Quota_100 extends Notice_Base {
 	}
 
 	public function maybe_add_quota_100_notice() : void {
+		// Manually set the conditions to false to avoid showing the notice.
+		$this->conditions = false;
+		return;
+		
 		$plan_data = Settings::get( Settings::PLAN_DATA );
 
 		if ( ! $plan_data ) {
@@ -46,6 +50,7 @@ class Quota_100 extends Notice_Base {
 		} else {
 			$this->conditions = false;
 		}
+
 	}
 
 	public function print_js() {

--- a/modules/settings/notices/quota-100.php
+++ b/modules/settings/notices/quota-100.php
@@ -30,10 +30,6 @@ class Quota_100 extends Notice_Base {
 	}
 
 	public function maybe_add_quota_100_notice() : void {
-		// Manually set the conditions to false to avoid showing the notice.
-		$this->conditions = false;
-		return;
-		
 		$plan_data = Settings::get( Settings::PLAN_DATA );
 
 		if ( ! $plan_data ) {

--- a/modules/settings/notices/quota-80.php
+++ b/modules/settings/notices/quota-80.php
@@ -30,6 +30,10 @@ class Quota_80 extends Notice_Base {
 	}
 
 	public function maybe_add_quota_80_notice() : void {
+		// Manually set the conditions to false to avoid showing the notice.
+		$this->conditions = false;
+		return;
+		
 		$plan_data = Settings::get( Settings::PLAN_DATA );
 
 		if ( ! $plan_data ) {

--- a/modules/settings/notices/quota-80.php
+++ b/modules/settings/notices/quota-80.php
@@ -30,10 +30,6 @@ class Quota_80 extends Notice_Base {
 	}
 
 	public function maybe_add_quota_80_notice() : void {
-		// Manually set the conditions to false to avoid showing the notice.
-		$this->conditions = false;
-		return;
-		
 		$plan_data = Settings::get( Settings::PLAN_DATA );
 
 		if ( ! $plan_data ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove visit quota indications and related components from the accessibility plugin settings interface.

Main changes:
- Removed QuotaNotices component from layout rendering in app.js
- Removed visits quota bar from QuotaBarComponent rendering
- Updated quota calculation logic to exclude visits-related metrics
- Commented out the register_notices action hook in module.php

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
