### PR TITLE
[APP-1832] Fix scan dashboard UI width

### DIFF
--- a/modules/settings/assets/js/pages/assistant/index.js
+++ b/modules/settings/assets/js/pages/assistant/index.js
@@ -125,10 +125,10 @@ const StyledHeadingWrapper = styled(Box)`
 const StyledHeadingContainer = styled(Container)`
 	padding-top: ${({ theme }) => theme.spacing(4)};
 	padding-bottom: ${({ theme }) => theme.spacing(4)};
-	padding-left: 0;
-	padding-right: 0;
+	padding-left: ${({ theme }) => theme.spacing(4)};
+	padding-right: ${({ theme }) => theme.spacing(4)};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.values.sm}px) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.values.xl}px) {
 		padding-left: 0;
 		padding-right: 0;
 	}
@@ -137,10 +137,10 @@ const StyledHeadingContainer = styled(Container)`
 export const StyledContainer = styled(Container)`
 	padding-top: ${({ theme }) => theme.spacing(4)};
 	padding-bottom: ${({ theme }) => theme.spacing(4)};
-	padding-left: 0;
-	padding-right: 0;
+	padding-left: ${({ theme }) => theme.spacing(4)};
+	padding-right: ${({ theme }) => theme.spacing(4)};
 
-	@media (min-width: ${({ theme }) => theme.breakpoints.values.sm}px) {
+	@media (min-width: ${({ theme }) => theme.breakpoints.values.xl}px) {
 		padding-left: 0;
 		padding-right: 0;
 	}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix scan dashboard UI width by adjusting container padding for different screen sizes.
Main changes:
- Added default padding (4 spacing units) to containers for all screen sizes
- Changed media query breakpoint from sm to xl for zero padding
- Applied consistent padding behavior to both heading and main containers

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
