### PR TITLE
[APP-1804] Added support for php 8.4

### DIFF
--- a/classes/database/entry.php
+++ b/classes/database/entry.php
@@ -220,7 +220,7 @@ class Entry {
 	 *                           Optional.
 	 *                           Defaults to null. In this case, will raise only the defaults /changed/ event.
 	 */
-	private function trigger_change( $data, string $event = null ) : void {
+	private function trigger_change( $data, ?string $event = null ) : void {
 		if ( $event ) {
 			/**
 			 * event specific

--- a/classes/database/table.php
+++ b/classes/database/table.php
@@ -299,7 +299,7 @@ class Table {
 	 *
 	 * @return string|null The query result or NULL on error.
 	 */
-	public static function select_var( $fields = '*', $where = '1', int $limit = null, int $offset = null, string $join = '' ): ?string {
+	public static function select_var( $fields = '*', $where = '1', ?int $limit = null, ?int $offset = null, string $join = '' ): ?string {
 		return static::db()->get_var( static::build_sql_string( $fields, $where, $limit, $offset, $join ) );
 	}
 
@@ -333,7 +333,7 @@ class Table {
 	 *
 	 * @return string The SQL SELECT statement built according to the function parameters.
 	 */
-	private static function build_sql_string( $fields = '*', $where = '1', int $limit = null, int $offset = null, string $join = '', array $order_by = [], $group_by = '' ): string {
+	private static function build_sql_string( $fields = '*', $where = '1', ?int $limit = null, ?int $offset = null, string $join = '', array $order_by = [], $group_by = '' ): string {
 		if ( is_array( $fields ) ) {
 			$fields = implode( ', ', $fields );
 		}
@@ -414,7 +414,7 @@ class Table {
 	 *
 	 * @return array|object|\stdClass[]|null On success, an array of objects. Null on error.
 	 */
-	public static function select( $fields = '*', $where = '1', int $limit = null, int $offset = null, $join = '', array $order_by = [], $group_by = '' ) {
+	public static function select( $fields = '*', $where = '1', ?int $limit = null, ?int $offset = null, $join = '', array $order_by = [], $group_by = '' ) {
 		// TODO: handle $wpdb->last_error
 		$query = static::build_sql_string( $fields, $where, $limit, $offset, $join, $order_by, $group_by );
 		return static::db()->get_results( $query );
@@ -447,7 +447,7 @@ class Table {
 	 *
 	 * @return string[] Array of the values of the column as strings, or an empty one on error.
 	 */
-	public static function get_col( string $column = '', $where = '1', int $limit = null, int $offset = null, string $join = '', array $order_by = [] ) : array {
+	public static function get_col( string $column = '', $where = '1', ?int $limit = null, ?int $offset = null, string $join = '', array $order_by = [] ) : array {
 		return static::db()->get_col( static::build_sql_string( $column, $where, $limit, $offset, $join, $order_by ) );
 	}
 
@@ -521,7 +521,7 @@ class Table {
 	 *
 	 * @return false|int Number of rows affected or false on error
 	 */
-	public static function insert_many( array $data = [], string $columns = null ) {
+	public static function insert_many( array $data = [], ?string $columns = null ) {
 		if ( null === $columns ) {
 			$columns = static::get_columns_for_insert( $data );
 			if ( ! $columns ) {

--- a/modules/remediation/database/remediation-entry.php
+++ b/modules/remediation/database/remediation-entry.php
@@ -50,7 +50,7 @@ class Remediation_Entry extends Entry {
 	 * @param string $by_value
 	 * @param string|null $group
 	 */
-	public static function remove( string $by, string $by_value, string $group = null ) {
+	public static function remove( string $by, string $by_value, ?string $group = null ) {
 		$where = $group ? [
 			$by => $by_value,
 			'group' => $group,
@@ -113,7 +113,7 @@ class Remediation_Entry extends Entry {
 	 *
 	 * @return void
 	 */
-	public static function update_remediations_status( string $by, string $by_value, bool $status, string $group = null ): void {
+	public static function update_remediations_status( string $by, string $by_value, bool $status, ?string $group = null ): void {
 		$where = $group ? [
 			$by => $by_value,
 			'group' => $group,


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update parameter type declarations across database methods to support PHP 8.4 nullable type handling.
Main changes:
- Added '?' prefix to nullable int and string type hints in method parameters
- Updated function signatures in Table class to use nullable type hints for $limit and $offset parameters
- Modified Remediation_Entry class methods to use explicit nullable string parameter typing

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
