### PR TITLE
[APP-0000] fix woocommerce archive type

### DIFF
--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -124,7 +124,7 @@ class Utils {
 		if ( $wp_query->is_post_type_archive() ) {
 			$post_type = $wp_query->query_vars['post_type'];
 			if ( is_array( $post_type ) ) {
-				$post_type = implode( ', ', $post_type );
+				$post_type = implode( '_', $post_type );
 			}
 			return $post_type ?? 'unknown';
 		}

--- a/modules/remediation/classes/utils.php
+++ b/modules/remediation/classes/utils.php
@@ -122,7 +122,11 @@ class Utils {
 		}
 
 		if ( $wp_query->is_post_type_archive() ) {
-			return $wp_query->query_vars['post_type'] ?? 'unknown';
+			$post_type = $wp_query->query_vars['post_type'];
+			if ( is_array( $post_type ) ) {
+				$post_type = implode( ', ', $post_type );
+			}
+			return $post_type ?? 'unknown';
 		}
 
 		if ( $wp_query->is_singular() ) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix WooCommerce archive type handling to properly handle array post types in WordPress queries.
Main changes:
- Added array check for post_type query variable to handle WooCommerce's multiple post type archives
- Implemented array-to-string conversion using implode to create consistent archive type identifiers

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using. **[We'd love your feedback!](mailto:product@linearb.io)** 🚀</sub>
<!--end_gitstream_placeholder-->
