### PR TITLE
Fix error notices in some cases for the plugin links [APP-3066]

### DIFF
--- a/modules/core/components/revert-to-legacy.php
+++ b/modules/core/components/revert-to-legacy.php
@@ -31,8 +31,12 @@ class Revert_To_Legacy {
 	}
 
 	public function add_plugin_links( $links, $plugin_file_name ) {
+		if ( ! is_array( $links ) ) {
+			return $links;
+		}
+
 		if ( ! str_ends_with( $plugin_file_name, '/pojo-accessibility.php' ) ) {
-			return (array) $links;
+			return $links;
 		}
 
 		$custom_links['revert'] = sprintf(

--- a/modules/core/module.php
+++ b/modules/core/module.php
@@ -25,9 +25,13 @@ class Module extends Module_Base {
 		];
 	}
 
-	public function add_plugin_links( $links, $plugin_file_name ) : array {
+	public function add_plugin_links( $links, $plugin_file_name ) {
+		if ( ! is_array( $links ) ) {
+			return $links;
+		}
+
 		if ( ! str_ends_with( $plugin_file_name, '/pojo-accessibility.php' ) ) {
-			return (array) $links;
+			return $links;
 		}
 
 		$custom_links = [

--- a/tests/phpunit/plugin/modules/core/components/revert-to-legacy-test.php
+++ b/tests/phpunit/plugin/modules/core/components/revert-to-legacy-test.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace EA11y\Tests\Modules\Core\Components;
+
+use EA11y\Modules\Core\Components\Revert_To_Legacy as Tested_Component;
+use Eunit\Cases\Unit_Test;
+
+class Revert_To_Legacy extends Unit_Test {
+
+	private ?Tested_Component $revert_to_legacy = null;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->revert_to_legacy = new Tested_Component();
+	}
+
+	public function tearDown(): void {
+		parent::tearDown();
+
+		$this->revert_to_legacy = null;
+	}
+
+	public function test_add_plugin_links_with_null_links_for_other_plugin() {
+		$result = $this->revert_to_legacy->add_plugin_links( null, 'some-other-plugin/some-other-plugin.php' );
+
+		$this->assertNull( $result );
+	}
+
+	public function test_add_plugin_links_with_null_links_for_ally() {
+		$result = $this->revert_to_legacy->add_plugin_links( null, 'pojo-accessibility/pojo-accessibility.php' );
+
+		$this->assertNull( $result );
+	}
+
+	public function test_add_plugin_links_merges_existing_links_for_ally() {
+		$existing_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
+		$result = $this->revert_to_legacy->add_plugin_links( $existing_links, 'pojo-accessibility/pojo-accessibility.php' );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'revert', $result );
+		$this->assertArrayHasKey( 'deactivate', $result );
+		$this->assertSame( $existing_links['deactivate'], $result['deactivate'] );
+	}
+}

--- a/tests/phpunit/plugin/modules/core/module-test.php
+++ b/tests/phpunit/plugin/modules/core/module-test.php
@@ -18,4 +18,26 @@ class Module extends Module_Test_Base {
 		'Svg',
 		'Notificator',
 	];
+
+	public function test_add_plugin_links_with_null_links_for_other_plugin() {
+		$result = $this->module->add_plugin_links( null, 'some-other-plugin/some-other-plugin.php' );
+
+		$this->assertNull( $result );
+	}
+
+	public function test_add_plugin_links_with_null_links_for_ally() {
+		$result = $this->module->add_plugin_links( null, 'pojo-accessibility/pojo-accessibility.php' );
+
+		$this->assertNull( $result );
+	}
+
+	public function test_add_plugin_links_merges_existing_links_for_ally() {
+		$existing_links = [ 'deactivate' => '<a href="#">Deactivate</a>' ];
+		$result = $this->module->add_plugin_links( $existing_links, 'pojo-accessibility/pojo-accessibility.php' );
+
+		$this->assertIsArray( $result );
+		$this->assertArrayHasKey( 'settings', $result );
+		$this->assertArrayHasKey( 'deactivate', $result );
+		$this->assertSame( $existing_links['deactivate'], $result['deactivate'] );
+	}
 }


### PR DESCRIPTION
…cases
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Plugin link handlers were casting non-array `$links` to array, masking type errors instead of gracefully handling them. This fix adds explicit type validation to return early for invalid inputs, preventing silent failures.

## 2. What Changed (Where)

- `revert-to-legacy.php`: Added null/non-array guard clause; removed cast from conditional branch
- `module.php`: Added matching null/non-array guard; removed return type hint (`:array`), allowing nullable returns
- Test files: Added comprehensive test coverage for null and array inputs across both handlers

## 3. How It Works

Both `add_plugin_links()` handlers now validate input upfront: if `$links` isn't an array, return it as-is (preserving nulls). Only for pojo-accessibility plugin does the function merge custom links. Removing the return type hint allows the method to return `null` or other non-array values without type violation, matching WordPress filter callback flexibility.

## 4. Risks

None significant. Early return for non-array inputs is defensive and safe. Type hint removal is intentional to match actual behavior—callers already handle mixed return types.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
